### PR TITLE
fix for kernel 4.19

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1011,7 +1011,9 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#ifndef IEEE80211_MAX_AMPDU_BUF
 #define IEEE80211_MAX_AMPDU_BUF 0x40
+#endif
 
 
 /* Spatial Multiplexing Power Save Modes */

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1193,7 +1193,11 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+	, struct net_device *sb_dev
+	#else
 	, void *accel_priv
+	#endif
 	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
 	, select_queue_fallback_t fallback
 	#endif


### PR DESCRIPTION
/var/lib/dkms/rtl88x2bu/5.2.4.4/build/include/wifi.h:1014: error: "IEEE80211_MAX_AMPDU_BUF" redefined [-Werror]
 #define IEEE80211_MAX_AMPDU_BUF 0x40

In file included from /var/lib/dkms/rtl88x2bu/5.2.4.4/build/include/osdep_service_linux.h:86,
                 from /var/lib/dkms/rtl88x2bu/5.2.4.4/build/include/osdep_service.h:42,
                 from /var/lib/dkms/rtl88x2bu/5.2.4.4/build/include/drv_types.h:27,
                 from /var/lib/dkms/rtl88x2bu/5.2.4.4/build/core/rtw_ioctl_query.c:17:
./include/linux/ieee80211.h:1442: note: this is the location of the previous definition
 #define IEEE80211_MAX_AMPDU_BUF  0x100